### PR TITLE
Fixes for python3 and 32 bit arch

### DIFF
--- a/pymsgq.py
+++ b/pymsgq.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 
 import ctypes
 import os
+import sys
 import errno
 import logging
 libc=ctypes.CDLL('libc.so.6',use_errno=True)
@@ -35,6 +36,10 @@ IPC_NOWAIT=2048
 IPC_STAT=2
 IPC_SET=1
 MSG_NOERROR=4096
+
+# not available in python3
+unicode = str if sys.version_info.major == 3 else unicode
+
 #msgqbuf
 def _msgbuf(size):
     class __msgbuf(ctypes.Structure):
@@ -57,7 +62,7 @@ class _msgdsbuf(ctypes.Structure):
             ]
 
 class Msgq(object):
-    def __init__(self, key, create=False, max_msg_buff_sz=512*1024, max_msgq_buff_total_sz=1024*1024*16, perms=0666, passive = True):
+    def __init__(self, key, create=False, max_msg_buff_sz=512*1024, max_msgq_buff_total_sz=1024*1024*16, perms=0o666, passive = True):
         flags=perms
         if create:
             flags=IPC_CREAT|perms

--- a/pymsgq.py
+++ b/pymsgq.py
@@ -110,7 +110,7 @@ class Msgq(object):
                 return -1
             if eno == errno.EINTR:
                 return -2
-            raise Exception('send msgq error:%s' % os.strerror(cyptes.get_errno()))
+            raise Exception('send msgq error:%s' % os.strerror(ctypes.get_errno()))
         return err
 
     def recv(self, mtype=0, flags=IPC_NOWAIT):

--- a/pymsgq.py
+++ b/pymsgq.py
@@ -45,7 +45,7 @@ def _msgbuf(size):
     class __msgbuf(ctypes.Structure):
         _pack_ = 1
         _fields_ = [
-                ('mtype', ctypes.c_long, 8*8),
+                ('mtype', ctypes.c_long, 8*ctypes.sizeof(ctypes.c_long)),
                 ('mtext', ctypes.c_byte*size,),
                 ]
     return __msgbuf()
@@ -57,7 +57,7 @@ class _msgdsbuf(ctypes.Structure):
     _pack_ = 1
     _fields_ = [
             ('dummy_1', ctypes.c_byte*DS_STRUCT_DUMMY_OFFSET_SIZE),
-            ('msg_qbytes', ctypes.c_long, 8*8),
+            ('msg_qbytes', ctypes.c_long, 8*ctypes.sizeof(ctypes.c_long)),
             ('dummy_2', ctypes.c_byte*DS_STRUCT_DUMMY_PADDING_SIZE)
             ]
 


### PR DESCRIPTION
* Small fixes for python3: Octal number notation, define unicode as an alias to str.
* Support 32 bit systems like x86 or arm where long is 4 bytes (gcc, linux).