### PR TITLE
Load 'libc.dylib' or 'libc.so.6' depending on OS

### DIFF
--- a/pymsgq.py
+++ b/pymsgq.py
@@ -21,9 +21,10 @@ from __future__ import unicode_literals
 
 import ctypes
 import os
+import platform
 import errno
 import logging
-libc=ctypes.CDLL('libc.so.6',use_errno=True)
+libc=ctypes.CDLL("libc.{}".format("so.6" if platform.uname()[0] != "Darwin" else "dylib"),use_errno=True)
 _msgget = libc.msgget
 _msgsnd = libc.msgsnd
 _msgrcv = libc.msgrcv


### PR DESCRIPTION
Resolves this issue on Mac OS X v10.15.5:  

➜  pymsgq git:(master) ✗ python3
Python 3.7.7 (default, Mar 10 2020, 15:43:33)
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import msgq
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/msgq.py", line 26, in <module>
    libc=ctypes.CDLL('libc.so.6',use_errno=True)
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ctypes/__init__.py", line 364, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen(libc.so.6, 6): image not found
>>>